### PR TITLE
minor fix to the 'upward' generator

### DIFF
--- a/lib/generators/counter.rb
+++ b/lib/generators/counter.rb
@@ -30,7 +30,6 @@ class CounterGenerator < Generator
     desc.gsub(/\s+/, " ").strip
   end
 
-
   def next_chunk
     @skip = (@i + @skip) % 17 + 1
     @lcg = (@lcg * 6364136223846793005 + 1442695040888963407) % 2**64

--- a/lib/generators/ruby.rb
+++ b/lib/generators/ruby.rb
@@ -17,7 +17,8 @@ class RubyGenerator < Generator
 
   def description
     desc = <<-DESC_END
-      TBD
+      This generator uses Ruby's built-in PRNG with a deterministic seed to
+      produce data.
     DESC_END
     desc.gsub(/\s+/, " ").strip
   end

--- a/lib/generators/upward.rb
+++ b/lib/generators/upward.rb
@@ -32,12 +32,11 @@ class UpwardGenerator < Generator
 
   def next_chunk
     @i += 1
-    ret = ''
-    ret << Digest::MD5.digest([@i].pack('Q>'))
-    md5 = Digest::MD5.digest([@i].pack('Q<'))
-    msb = md5[0].ord
-    ret << md5[0] = ('%08b' % msb).reverse.to_i(2).chr if msb < 43
-    ret
+    pristine = Digest::MD5.digest([@i].pack('Q>'))
+    nudged = Digest::MD5.digest([@i].pack('Q<'))
+    msb = nudged[0].ord
+    nudged[0] = ('%08b' % msb).reverse.to_i(2).chr if msb < 43
+    pristine << nudged
   end
 
 end


### PR DESCRIPTION
This generator used to produce two MD5 checksums per iteration - one that was delivered raw, and another that was delivered with the first byte skewed upwards. The most recent modification only delivered the first byte of the second MD5.
Fixing the variable names should help.
