### PR TITLE
usability improvements and baseline updates

### DIFF
--- a/bin/entrospect
+++ b/bin/entrospect
@@ -51,9 +51,8 @@ begin
   raise "Invalid option: #{ARGV.first}" unless ARGV.empty?
   if opts[:src].class <= Class and opts[:src] <= Generator
     opts[:src] = opts[:src].new(opts[:limit])
-  end
-  if opts[:src].class <= File and opts[:limit] < opts[:src].size
-    opts[:src].pos = opts[:src].size - opts[:limit]
+  else
+    opts[:src] = IOGenerator.new(opts[:src], opts[:limit])
   end
 rescue
   $stderr.puts "Error: #{$!}"

--- a/lib/entrospection.rb
+++ b/lib/entrospection.rb
@@ -83,7 +83,7 @@ class Entrospection
           # double our sampling interval.
           if @pvalue[:binomial].length == 1024
             @pvalue.keys.each do |ptype|
-              512.times { |i| @pvalue[ptype].delete_at i }
+              512.times { |i| @pvalue[ptype][i, 2] = @pvalue[ptype][i, 2].min }
             end
             @pvalue_interval *= 2
           end

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -22,9 +22,11 @@ class Generator
   def self.run(dst = $stdout)
     Signal.trap("INT") { exit(0) }
     limit = Float::INFINITY
-    if ARGV[0].to_i != 0
-      unit = { 'k' => 1024, 'm' => 2**20, 'g' => 2**30 }[ARGV[0][-1].downcase]
-      limit = ARGV[0].to_i * (unit || 1)
+    if ARGV.last.to_i != 0
+      unit = { 'k' => 1024, 'm' => 2**20, 'g' => 2**30 }[ARGV.last[-1].downcase]
+      limit = ARGV.last.to_i * (unit || 1)
+    else
+      raise "Invalid command line arguments" unless ARGV.empty?
     end
     generator = self.new(limit)
     generator.pipe_to(dst) if dst
@@ -120,6 +122,21 @@ class Generator
 
   def self.gmap
     @@gmap
+  end
+
+end
+
+# This class takes an IO object and mimics a Generator, which in turn mimics
+# an IO object (only with an enforced read limit).
+class IOGenerator < Generator
+
+  def initialize(io, limit = Float::INFINITY)
+    super(limit)
+    @src_o = io
+  end
+
+  def next_chunk
+    @src_o.readpartial(64)
   end
 
 end

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -96,7 +96,9 @@ class Generator
 
   # List all subclasses (effectively list all generators)
   def self.descendants
-    ObjectSpace.each_object(Class).select { |klass| klass < self }
+    kids = ObjectSpace.each_object(Class).select do |klass|
+      klass < self and klass != IOGenerator
+    end
   end
 
   def self.load_all

--- a/lib/generators/increment.rb
+++ b/lib/generators/increment.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+# This generator simply loops through all byte values, 0 - 255, in order.
+# It's used as a basic sanity check against whiteners - they shouldn't whiten
+# this data.
+
+require_relative '../generator.rb'
+
+class IncrementGenerator < Generator
+
+  def initialize(*args)
+    super(*args)
+    @bytes = (0..255).collect { |x| x.chr }.join
+  end
+
+  def self.summary
+    "Simple incrementing counter"
+  end
+
+  def self.description
+    desc = <<-DESC_END
+    This generator merely outputs all byte values in order over and over.
+    DESC_END
+    desc.gsub(/\s+/, " ").strip
+  end
+
+  def next_chunk
+    @bytes.dup
+  end
+
+end
+
+IncrementGenerator.run if __FILE__ == $0
+

--- a/test/baseline.txt
+++ b/test/baseline.txt
@@ -70,6 +70,12 @@ ruby:               89.6%
 ruby:               64.2%
 ruby:               59.3%
 
+  -- sha512 --
+sha512:             29.9%
+sha512:             90.5%
+sha512:             65.0%
+sha512:             27.2%
+
   -- upward --
 upward:             50.5%
 upward:             91.3%

--- a/test/baseline.txt
+++ b/test/baseline.txt
@@ -28,6 +28,12 @@ icg:                91.4%
 icg:                51.6%
 icg:                57.4%
 
+  -- increment --
+increment:          87.3%
+increment:          99.9%
+increment:          00.0%
+increment:          00.0%
+
   -- lcg --
 lcg:                36.0%
 lcg:                91.6%


### PR DESCRIPTION
- now byte limits are uniformly enforced for stdin and reading from a file
- when compressing pvalue arrays, the minimum value is preserved instead of random sampling
- error reporting for invalid byelimit arguments to the generators
- new generator: simple montonic byte value counter
