### PR TITLE
Add limited pi generator

### DIFF
--- a/entrospection.gemspec
+++ b/entrospection.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.executables   << 'entrocine'
 
   s.add_development_dependency 'bundler'
+  s.add_development_dependency 'rake'
 
   s.add_runtime_dependency 'chunky_png'
 end

--- a/lib/generators/pi.rb
+++ b/lib/generators/pi.rb
@@ -36,8 +36,8 @@ class PiGenerator < Generator
 
     # Perform the first, 'left', sum of the bbp formula
     while k <= n
-      r = (8.0 * k) + j
-      left = (left + (((16**n).modulo(r)) / r)).modulo(1.0)
+      r = (8 * k) + j
+      left = (left + (((16**(n-k)) % r) / r.to_f))
       k +=1
     end
 
@@ -45,32 +45,39 @@ class PiGenerator < Generator
     k = n+1
     stable = false
     while !stable
-      tempRight = right + ((16 ** (n - k)) / ((8 * k) +j))
+      tempRight = (right + ((16 ** (n - k)) / ((8.0 * k) +j)))
       if right == tempRight
         stable = true
+      else
+        right = tempRight
       end
-      right = tempRight
       k += 1
     end
 
     left + right
-
   end
 
-  # Overflows ruby floating point at, and above, 257
+  # Perform the summation to calculate the n-th digit of pi
+  def sumPart(n)
+    a = 4 * S(1,n)
+    b = 2 * S(4,n)
+    c = S(5,n)
+    d = S(6,n)
+    (a - b - c - d) % 1
+  end
+
   def bbp(n)
     n -=1
-    # Perform the summation to calculate the n-th digit of pi
-    x = ( 4 * S(1,n) - 2 * S(4,n) - S(5,n) - S(6,n)).modulo(1.0)
-    # This will give back 7 hex digits of pi, even though we only care about the first
-    z = (x * 16**7)
-    "%07x" % z
+    x = sumPart(n)
+    y = (x * (16**14))
+    "%x" % y
   end
 
   def next_chunk
     @i +=1
-    x = bbp(@i).to_s.chars[0]
-    [ x ].pack('A')
+    x = bbp(@i).to_s[0]
+    y = "%b" % x.to_i(16)
+    [ y ].pack('p')
   end
 
 end

--- a/lib/generators/pi.rb
+++ b/lib/generators/pi.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+# This generates a pseudo-random sequence, the digits of pi in hex
+# Digits are calculated using the method as described at
+# https://en.wikipedia.org/wiki/Bailey-Borwein-Plouffe_formula
+
+
+require_relative '../generator.rb'
+
+class PiGenerator < Generator
+
+  def initialize(*args)
+    super(*args)
+    @i = -1
+  end
+
+  def self.summary
+    "Pseudo-random number generator using calculated digits of pi"
+  end
+
+  def self.description
+    desc = <<-DESC_END
+      This generator uses the Bailey-Borwein-Plouffe formula of calculating
+      the nth digit of pi without needing to calculate previous digits.
+      Digits of pi, in hexidecimal, are used as pseudo random numbers.
+    DESC_END
+    desc.gsub(/\s+/, " ").strip
+  end
+
+
+  # Perform one of the summations in the bbp formula
+  def S(j,n)
+    left = 0.0
+    k = 0
+    right = 0.0
+
+    # Perform the first, 'left', sum of the bbp formula
+    while k <= n
+      r = (8.0 * k) + j
+      left = (left + (((16**n).modulo(r)) / r)).modulo(1.0)
+      k +=1
+    end
+
+    # Perform the 'right' sum of the bbp formula
+    k = n+1
+    stable = false
+    while !stable
+      tempRight = right + ((16 ** (n - k)) / ((8 * k) +j))
+      if right == tempRight
+        stable = true
+      end
+      right = tempRight
+      k += 1
+    end
+
+    left + right
+
+  end
+
+  # Overflows ruby floating point at, and above, 257
+  def bbp(n)
+    n -=1
+    # Perform the summation to calculate the n-th digit of pi
+    x = ( 4 * S(1,n) - 2 * S(4,n) - S(5,n) - S(6,n)).modulo(1.0)
+    # This will give back 7 hex digits of pi, even though we only care about the first
+    z = (x * 16**7)
+    "%07x" % z
+  end
+
+  def next_chunk
+    @i +=1
+    x = bbp(@i).to_s.chars[0]
+    [ x ].pack('A')
+  end
+
+end
+
+PiGenerator.run if __FILE__ == $0


### PR DESCRIPTION
Some notes:
- It has been a while since I've used Ruby beyond just a script in a shell, so I'm not sure why the rake dependency was needed, but I couldn't get the code without my changes to work without it.
- Digits of pi are calculated using the BBP formula https://en.wikipedia.org/wiki/Bailey%E2%80%93Borwein%E2%80%93Plouffe_formula
- For some reason there seems to be a float overflow around 10^18, even though the max float as documented at http://ruby-doc.org/core-2.2.0/Float.html is around 1.7 x 10^308. Again, been a while since I've done Ruby, so I'm not certain what is going on here. Even if it wasn't a float, I thought Ruby automatically converts to bignums.
- Given the above the performance, in terms of 'randomness', is actually pretty bad. Any advice?
